### PR TITLE
Some README.me updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ Built by backporting the 7.12 ARM64 Dockerfile and copying the JDK from the 7.12
 
 # Building the image
 ```
-docker build . -t public.ecr.aws/c2m6n8k8/elasticsearch-arm:6.8
+docker build . -t elasticsearch-arm:6.8
+```
+
+# Publish the image to Github Registry
+```
+docker tag elasticsearch-arm:6.8 ghcr.io/Baladins/elasticsearch-arm:6.8
+echo $GITHUB_TOKEN | docker login ghcr.io -u $USERNAME --password-stdin
+docker push ghcr.io/baladins/elasticsearch-docker-arm64:6.8
+```
+
+# Publish the image to AWS Registry
+```
+docker tag elasticsearch-arm:6.8 public.ecr.aws/c2m6n8k8/elasticsearch-arm:6.8
 aws ecr-public get-login-password --region=us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 docker push public.ecr.aws/c2m6n8k8/elasticsearch-arm:6.8
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Built by backporting the 7.12 ARM64 Dockerfile and copying the JDK from the 7.12
 docker build . -t elasticsearch-arm:6.8
 ```
 
+# Running the image
+To run it:
+
+```
+docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node"  -e "xpack.ml.enabled=false" elasticsearch-arm:6.8
+```
+
 # Publish the image to Github Registry
 ```
 docker tag elasticsearch-arm:6.8 ghcr.io/Baladins/elasticsearch-arm:6.8
@@ -19,11 +26,4 @@ docker push ghcr.io/baladins/elasticsearch-docker-arm64:6.8
 docker tag elasticsearch-arm:6.8 public.ecr.aws/c2m6n8k8/elasticsearch-arm:6.8
 aws ecr-public get-login-password --region=us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 docker push public.ecr.aws/c2m6n8k8/elasticsearch-arm:6.8
-```
-
-# Running the image
-To run it:
-
-```
-docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node"  -e "xpack.ml.enabled=false" elyalvarado/elasticsearch:6.8
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Built by backporting the 7.12 ARM64 Dockerfile and copying the JDK from the 7.12
 docker build . -t elasticsearch-arm:6.8
 ```
 
+# Get image from Github Registry
+```
+docker pull ghcr.io/baladins/elasticsearch-docker-arm64:6.8.24
+docker tag ghcr.io/baladins/elasticsearch-docker-arm64:6.8.24 elasticsearch-arm:6.8
+```
+
 # Running the image
 To run it:
 


### PR DESCRIPTION
Hello, thank you for you work on hosting the bin on S3 to avoid Git LFS quota issue.
I published the image on github, see README update if you wan to do the same.

https://github.com/orgs/Baladins/packages/container/package/elasticsearch-docker-arm64